### PR TITLE
remove trailing comma

### DIFF
--- a/src/harfbuzz.js
+++ b/src/harfbuzz.js
@@ -1,6 +1,6 @@
 // Provides: rehb_new_face
 function rehb_new_face(
-  _fontName /*: string */,
+  _fontName /*: string */
 ) {
   return undefined;
 }


### PR DESCRIPTION
Hi !
I've been trying to compile my revery project to JS, but I had [this issue](https://github.com/ocsigen/js_of_ocaml/issues/989).

This is due to the fact that js_of_ocaml does not support ES7 syntax.